### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Server 来访问七牛云存储、智能多媒体服务等。
   - 根据链接刷新文件
   - 根据链接预取文件
 
+<a href="https://glama.ai/mcp/servers/@qiniu/qiniu-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@qiniu/qiniu-mcp-server/badge" alt="Qiniu Server MCP server" />
+</a>
+
 ## 环境要求
 
 - Python 3.12 或更高版本
@@ -175,7 +179,3 @@ uv --directory . run qiniu-mcp-server
 ```bash
 uv --directory . run qiniu-mcp-server --transport sse --port 8000
 ```
-
-
-
-


### PR DESCRIPTION
This PR adds a badge for the [Qiniu MCP Server](https://glama.ai/mcp/servers/@qiniu/qiniu-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@qiniu/qiniu-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@qiniu/qiniu-mcp-server/badge" alt="Qiniu Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.